### PR TITLE
Fix the Expression evaluator 

### DIFF
--- a/src/common/defs.h
+++ b/src/common/defs.h
@@ -22,41 +22,6 @@
 
 #pragma once
 
-#include "common/defs.h"
+#include <cstdint>
 
-#include <string>
-#include <vector>
-
-// TODO: Currently we're limited to whatever size `int` is
-namespace Maths {
-
-struct Token {
-  bool isNumber;
-  char asOperator;
-  floatmax_t asNumber;
-
-  // TODO: Find a better API than these factory functions
-  static inline Token number(floatmax_t number) { return Token(true, 0, number); }
-
-  static inline Token operation(char anOperator) { return Token(false, anOperator, 0); }
-
-  inline bool operator==(const char &anOperator) const { return !isNumber && asOperator == anOperator; }
-
-  inline bool operator==(const Token &o) const {
-    if (isNumber != o.isNumber) return false;
-    if (isNumber) {
-      return asNumber == o.asNumber;
-    } else {
-      return asOperator == o.asOperator;
-    }
-  }
-
-private:
-  inline Token(bool isNumber, char asOperator, floatmax_t asNumber)
-      : isNumber(isNumber), asOperator(asOperator), asNumber(asNumber) {}
-};
-
-std::vector<Token> tokenizeExpression(const std::string &);
-
-floatmax_t evaluateExpression(const std::string &);
-}
+using floatmax_t = long double;

--- a/src/maths/expressions.cpp
+++ b/src/maths/expressions.cpp
@@ -48,18 +48,18 @@ vector<Token> Maths::tokenizeExpression(const string &expression) {
     }
 
     if (currentNumber != 0) {
-      tokens.push_back(Token::number(currentNumber));
+      tokens.emplace_back(currentNumber);
       isReadingNumber = false;
       currentNumber = 0;
     }
 
     if (token != ' ') {
-      tokens.push_back(Token::operation(token));
+      tokens.push_back(Token::fromChar(token));
     }
   }
 
   if (isReadingNumber) {
-    tokens.push_back(Token::number(currentNumber));
+    tokens.emplace_back(currentNumber);
   }
 
   return tokens;

--- a/src/maths/expressions.cpp
+++ b/src/maths/expressions.cpp
@@ -37,7 +37,7 @@ vector<Token> Maths::tokenizeExpression(const string &expression) {
   vector<Token> tokens;
 
   bool isReadingNumber = false;
-  int currentNumber = 0;
+  floatmax_t currentNumber = 0;
 
   for (auto token : expression) {
     if (token >= '0' && token <= '9') {
@@ -48,18 +48,18 @@ vector<Token> Maths::tokenizeExpression(const string &expression) {
     }
 
     if (currentNumber != 0) {
-      tokens.emplace_back(currentNumber);
+      tokens.push_back(Token::number(currentNumber));
       isReadingNumber = false;
       currentNumber = 0;
     }
 
     if (token != ' ') {
-      tokens.emplace_back(token);
+      tokens.push_back(Token::operation(token));
     }
   }
 
   if (isReadingNumber) {
-    tokens.emplace_back(currentNumber);
+    tokens.push_back(Token::number(currentNumber));
   }
 
   return tokens;
@@ -75,7 +75,7 @@ inline uint_fast8_t getPrecedence(char operation) {
   return 0;
 }
 
-void reduceOnce(stack<int> *numbers, stack<char> *operators) {
+void reduceOnce(stack<floatmax_t> *numbers, stack<char> *operators) {
   auto next = operators->top();
   operators->pop();
 
@@ -100,7 +100,7 @@ void reduceOnce(stack<int> *numbers, stack<char> *operators) {
   }
 }
 
-inline void reduceToParenthesis(stack<int> *numbers, stack<char> *operators) {
+inline void reduceToParenthesis(stack<floatmax_t> *numbers, stack<char> *operators) {
   assert(!operators->empty());
   while (operators->top() != '(') {
     reduceOnce(numbers, operators);
@@ -109,14 +109,14 @@ inline void reduceToParenthesis(stack<int> *numbers, stack<char> *operators) {
   operators->pop();
 }
 
-inline void reduceToPrecedence(stack<int> *numbers, stack<char> *operators, uint_fast8_t precedence) {
+inline void reduceToPrecedence(stack<floatmax_t> *numbers, stack<char> *operators, uint_fast8_t precedence) {
   while (!operators->empty() && getPrecedence(operators->top()) >= precedence) {
     reduceOnce(numbers, operators);
   }
 }
 
-int Maths::evaluateExpression(const std::string &expression) {
-  stack<int> numbers;
+floatmax_t Maths::evaluateExpression(const std::string &expression) {
+  stack<floatmax_t> numbers;
   stack<char> operators;
   int parenthesisCount = 0;
 
@@ -124,7 +124,7 @@ int Maths::evaluateExpression(const std::string &expression) {
     if (token == ' ') continue;
 
     if (token.isNumber) {
-      numbers.push(token.value.asNumber);
+      numbers.push(token.asNumber);
     } else if (token == '(') {
       operators.push('(');
       parenthesisCount++;
@@ -132,9 +132,11 @@ int Maths::evaluateExpression(const std::string &expression) {
       assert(parenthesisCount > 0);
       parenthesisCount--;
       reduceToParenthesis(&numbers, &operators);
+    } else if (token == '^') {
+      operators.push('^');
     } else {
-      reduceToPrecedence(&numbers, &operators, getPrecedence(token.value.asOperator));
-      operators.push(token.value.asOperator);
+      reduceToPrecedence(&numbers, &operators, getPrecedence(token.asOperator));
+      operators.push(token.asOperator);
     }
   }
 

--- a/src/maths/expressions.h
+++ b/src/maths/expressions.h
@@ -35,10 +35,9 @@ struct Token {
   char asOperator;
   floatmax_t asNumber;
 
-  // TODO: Find a better API than these factory functions
-  static inline Token number(floatmax_t number) { return Token(true, 0, number); }
+  Token(floatmax_t number) : isNumber(true), asOperator(0), asNumber(number) {} // NOLINT(google-explicit-constructor)
 
-  static inline Token operation(char anOperator) { return Token(false, anOperator, 0); }
+  static inline Token fromChar(char anOperator) { return Token(false, anOperator, 0); }
 
   inline bool operator==(const char &anOperator) const { return !isNumber && asOperator == anOperator; }
 

--- a/src/maths/runner.cpp
+++ b/src/maths/runner.cpp
@@ -69,5 +69,5 @@ bool runEvaluateExpression(const string &expression, long expected) {
 }
 
 bool Maths::run() {
-  return runLargestPrimeFactor(13195, 29) && runEvaluateExpression("3 + 4 * 2 / ( 1 - 5 ) ^ 2 ^ 3 - 1 / 8192", 3);
+  return runLargestPrimeFactor(13195, 29) && runEvaluateExpression("3 + (4 * 2) ^ 2 ^ 3 / ( 1 - 5 ) ^ 2", 1048579);
 }

--- a/tests/maths/maths_expressions_test.cpp
+++ b/tests/maths/maths_expressions_test.cpp
@@ -45,10 +45,23 @@ TEST(Expressions, Evaluator) {
   EXPECT_EQ(evaluateExpression("2*(3*(1+2)+2)"), 22);
   EXPECT_EQ(evaluateExpression("123*456"), 56088);
   EXPECT_EQ(evaluateExpression("3 + 4 * 2 / ( 1 - 5 ) ^ 2 ^ 3 - 1 / 8192"), 3);
+  EXPECT_EQ(evaluateExpression("3 + 4 * (2 ^ 2) ^ 3 / ( 1 - 5 ) ^ 2"), 19);
+  EXPECT_EQ(evaluateExpression("3 + 4 * 2 ^ 2 ^ 3 / ( 1 - 5 ) ^ 2"), 67);
+  EXPECT_EQ(evaluateExpression("3 + (4 * 2) ^ 2 ^ 3 / ( 1 - 5 ) ^ 2"), 1048579);
+  EXPECT_EQ(evaluateExpression(" 3 + (4 * 2) ^ 2 ^ 3 ^ 1 ^ 1 / ( 1 - 5 ) ^ 2 ^ 3"), 259);
 }
 
 TEST(Expressions, Tokenizer) {
-  EXPECT_EQ(tokenizeExpression("1 +2"), vector<Token>({1, '+', 2}));
-  EXPECT_EQ(tokenizeExpression("1000/123"), vector<Token>({1000, '/', 123}));
-  EXPECT_EQ(tokenizeExpression("0"), vector<Token>({Token(0)}));
+  Token zero = Token::number(0);
+  Token one = Token::number(1);
+  Token two = Token::number(2);
+  Token hundredTwentyThree = Token::number(123);
+  Token thousand = Token::number(1000);
+
+  Token plus = Token::operation('+');
+  Token division = Token::operation('/');
+
+  EXPECT_EQ(tokenizeExpression("1 +2"), vector({one, plus, two}));
+  EXPECT_EQ(tokenizeExpression("1000/123"), vector({thousand, division, hundredTwentyThree}));
+  EXPECT_EQ(tokenizeExpression("0"), vector({zero}));
 }

--- a/tests/maths/maths_expressions_test.cpp
+++ b/tests/maths/maths_expressions_test.cpp
@@ -52,16 +52,10 @@ TEST(Expressions, Evaluator) {
 }
 
 TEST(Expressions, Tokenizer) {
-  Token zero = Token::number(0);
-  Token one = Token::number(1);
-  Token two = Token::number(2);
-  Token hundredTwentyThree = Token::number(123);
-  Token thousand = Token::number(1000);
+  auto plus = Token::fromChar('+');
+  auto divided = Token::fromChar('/');
 
-  Token plus = Token::operation('+');
-  Token division = Token::operation('/');
-
-  EXPECT_EQ(tokenizeExpression("1 +2"), vector({one, plus, two}));
-  EXPECT_EQ(tokenizeExpression("1000/123"), vector({thousand, division, hundredTwentyThree}));
-  EXPECT_EQ(tokenizeExpression("0"), vector({zero}));
+  EXPECT_EQ(tokenizeExpression("1 +2"), vector<Token>({1, plus, 2}));
+  EXPECT_EQ(tokenizeExpression("1000/123"), vector<Token>({1000, divided, 123}));
+  EXPECT_EQ(tokenizeExpression("0"), vector({Token(0)}));
 }


### PR DESCRIPTION
Turns out the evaluator wasn't doing floating point numbers correctly, and we were just getting the correct results in our tests out of sheer luck. Now we're using floats instead of ints, and we've fixed the behavior of the power (^) operator.