### PR TITLE
Fix the Build Status Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://github.com/emanuelmch/puzzles/actions/workflows/check.yml/badge.svg?branch=master)](https://github.com/emanuelmch/puzzles/actions/workflows/check.yml)
+[![Build Status](https://github.com/emanuelmch/puzzles/actions/workflows/core_check.yml/badge.svg?branch=master)](https://github.com/emanuelmch/puzzles/actions/workflows/core_check.yml)
 
 # Puzzles
 


### PR DESCRIPTION
It got borked when we renamed the "check" workflow to "Core Action" when we added the web module